### PR TITLE
Issues should only have a single state after all

### DIFF
--- a/spec/Semantics.md
+++ b/spec/Semantics.md
@@ -36,6 +36,8 @@ inheritance of extended states is transitive with regard to the relation
 "extends". Thus, the relation "depends on" is also both anti-symmetric and
 transitive.
 
+The relation given by the union of the relations "overrides" and "extends" shall
+also be anti-symmetric and transitive.
 
 ## Names
 

--- a/spec/Semantics.md
+++ b/spec/Semantics.md
@@ -12,9 +12,8 @@ function mapping an issue's metadata to a truth value. A state is said to be
 "enabled" for a given issue if this function yields "true" for the issue's
 metadata, e.g. if the condition is satisfied.
 
-Contrary to what is common for issue- and bugtrackers, multiple states may be
-engaged for an issue, e.g. if the metadata satisfies the specifications of
-multiple issue states. Also contrary to common workflow concepts, state
+An issue exhibits at most one state at a given time. This state has to be one of
+the enabled states for the issue. Contrary to common workflow concepts, state
 transitions are not modeled --hence the name "issue-states" rather than
 something containing "workflow". Thus, no restrictions or actions can be
 associated with an transition. If a user can arbitrarily alter issue metadata,

--- a/spec/Semantics.md
+++ b/spec/Semantics.md
@@ -23,9 +23,9 @@ it can be assumed that he or she may put the issue in any state specified.
 ## Relations between states
 
 An issue state may "override" one or more other issue states if specified:
-if a state is "engaged" due to the issue's metadata, states overridden by
-this state are "disengaged", e.g. no longer visible to the user regardless of
-whether the metadata satisfies the state's perquisites. The relation "overrides"
+if the state is enabled, the issue cannot exhibit any of the states overridden.
+For example, if two states are enabled for an issue but one overrides the other,
+the overriding state is selected as the issue's state. The relation "overrides"
 is both anti-symmetric and transitive. Since an issue state should naturally
 never override itself, the graph given by issue states and the relation should
 be free of cycles.

--- a/spec/Semantics.md
+++ b/spec/Semantics.md
@@ -39,13 +39,6 @@ transitive.
 The relation given by the union of the relations "overrides" and "extends" shall
 also be anti-symmetric and transitive.
 
-## Names
-
-States have a name, which is part of the state's specification. A state's
-specification may also contain the name of a "counter-state". This introduces a
-pseudo state which is engaged if, and only if, the original state is disengaged.
-A state cannot depend or override a counter-state directly or transitively.
-
 
 ## Note on computability
 

--- a/spec/Semantics.md
+++ b/spec/Semantics.md
@@ -26,9 +26,7 @@ An issue state may "override" one or more other issue states if specified:
 if the state is enabled, the issue cannot exhibit any of the states overridden.
 For example, if two states are enabled for an issue but one overrides the other,
 the overriding state is selected as the issue's state. The relation "overrides"
-is both anti-symmetric and transitive. Since an issue state should naturally
-never override itself, the graph given by issue states and the relation should
-be free of cycles.
+is both anti-symmetric and transitive.
 
 An issue state may also "depend" on one or more other issue states, e.g. the
 state is only engaged if all issue states it depends on are engaged. Like the

--- a/spec/Semantics.md
+++ b/spec/Semantics.md
@@ -28,11 +28,13 @@ For example, if two states are enabled for an issue but one overrides the other,
 the overriding state is selected as the issue's state. The relation "overrides"
 is both anti-symmetric and transitive.
 
-An issue state may also "depend" on one or more other issue states, e.g. the
-state is only engaged if all issue states it depends on are engaged. Like the
-relation "overrides", the relation "depends on" is both anti-symmetric and
-transitive. Also, the corresponding graph should be free of cycles. An issue
-cannot depends on an issue and override the same issue at the same time.
+An issue state may "extend" on one or more other issue states. This relation
+has the same effect as the "override" relation. However, the extending state
+inherits the conditions of the extended states, e.g. the state is only enabled
+if its own condition is satisfied and all states it extends are enabled. The
+inheritance of extended states is transitive with regard to the relation
+"extends". Thus, the relation "depends on" is also both anti-symmetric and
+transitive.
 
 
 ## Names

--- a/spec/Semantics.md
+++ b/spec/Semantics.md
@@ -4,8 +4,7 @@ The central objects of interest are the states an issue may have, henceforth
 referred to as "issue states". However, in this project, issue states are not
 a property which is actively assigned to an issue but rather a property which is
 inferred from its metadata, based on the specification. For example, an issue
-may exhibit the state "assigned" if an assignee is present for the issue. An
-issue state is either "engaged" or "disengaged".
+may exhibit the state "assigned" if an assignee is present for the issue.
 
 An issue state is associated with a "condition", which is conceptually a pure
 function mapping an issue's metadata to a truth value. A state is said to be

--- a/spec/Semantics.md
+++ b/spec/Semantics.md
@@ -7,6 +7,11 @@ inferred from its metadata, based on the specification. For example, an issue
 may exhibit the state "assigned" if an assignee is present for the issue. An
 issue state is either "engaged" or "disengaged".
 
+An issue state is associated with a "condition", which is conceptually a pure
+function mapping an issue's metadata to a truth value. A state is said to be
+"enabled" for a given issue if this function yields "true" for the issue's
+metadata, e.g. if the condition is satisfied.
+
 Contrary to what is common for issue- and bugtrackers, multiple states may be
 engaged for an issue, e.g. if the metadata satisfies the specifications of
 multiple issue states. Also contrary to common workflow concepts, state


### PR DESCRIPTION
Having multiple states is quite exotic. That was quite obvious.

However, after giving it some more thought, I realized that it doesn't really bring a huge benefit. Enabling multiple issue states also made the computation more complex.

Also, after the redefinition the relations make more sense: they share the same "direction" and together form a union-relation. In practice, this greatly simplifies the computation of an issue's state.