### PR TITLE
Update specification of the structure

### DIFF
--- a/spec/Structure.md
+++ b/spec/Structure.md
@@ -30,11 +30,11 @@ other case, the item consists of a map describing the state.
    place of a list containing only one item. The state's condition is the
    conjunction of all the sub-conditions expressed through the individual
    strings.
- * An entry with the key `depends-on` denotes other states the current state
-   depends on. The value of this entry is a list of strings, each representing
-   an issue-state's name. Alternatively, if the state depends only on a single
-   other state, a single string may be used.
+ * The optional entry with the key `extends` denotes states which are extended
+   by the current state. The value of this entry is a list of strings, each
+   matching an issue-state's name. Alternatively, if the state depends only on a
+   single other state, a single string may be used.
  * An entry with the key `overrides` denotes states which are overridden by the
-   current state. Like for the `depends-on` entry, its value is a list of state
+   current state. Like for the `extends` entry, its value is a list of state
    names or a single state name.
 

--- a/spec/Structure.md
+++ b/spec/Structure.md
@@ -23,12 +23,13 @@ other case, the item consists of a map describing the state.
 
  * The mandatory entry with the key `name` denotes the issue state's name. The
    value of this entry is the name
- * An entry with the key `condition` denotes the metadata condition. The value
-   of this entry is a list of strings containing conditions for single pieces of
-   metadata in implementation defined behavior. If the condition of the state
-   if expressible using a single string, this string may be used in place of a
-   list containing only one item. The state's condition is the conjunction of
-   all the sub-conditions expressed through the individual strings.
+ * The optional entry with the key `condition` denotes the metadata condition.
+   The value of this entry is a list of strings containing conditions for single
+   pieces of metadata in an implementation defined format. If the condition of
+   the state is expressible using a single string, this string may be used in
+   place of a list containing only one item. The state's condition is the
+   conjunction of all the sub-conditions expressed through the individual
+   strings.
  * An entry with the key `depends-on` denotes other states the current state
    depends on. The value of this entry is a list of strings, each representing
    an issue-state's name. Alternatively, if the state depends only on a single

--- a/spec/Structure.md
+++ b/spec/Structure.md
@@ -2,8 +2,8 @@
 
 An issue state specification consist of a list or sequence of descriptions of
 issue state. Each issue state is identified by a unique, mandatory name.
-It may contain one name for a counter-state as well as a specification for
-the metadata conditions, dependet-on issue states and overridden issue states.
+It may contain a specification for the metadata conditions as well as references
+to other issue states extended and overridden by the state.
 
 
 ## YAML 1.2
@@ -18,16 +18,12 @@ The top-level node of an issue state specifying YAML document is a sequence.
 Each item of that sequence describes one issue state.
 
 In the most simple case, the item consists of the state's name, represented as a
-string. Such an item represents a state which is unconditionally engaged (unless
-overridden by another state), without a counter-state.
+string. Such an item represents a state which is unconditionally enabled.
 
 In any other case, the item consists of a map with exactly one entry. The
 entry's key represents the state's name. The value is a map representing the
 state's properties. Each of those properties is optional:
 
- * If an entry with the key `counter` is present, the a counter-state is
-   associated with the state. The value of this entry is the counter-state's
-   name, represented as a single string.
  * An entry with the key `condition` denotes the metadata condition. The value
    of this entry is a list of strings containing conditions for single pieces of
    metadata in implementation defined behavior. If the condition of the state

--- a/spec/Structure.md
+++ b/spec/Structure.md
@@ -18,12 +18,11 @@ The top-level node of an issue state specifying YAML document is a sequence.
 Each item of that sequence describes one issue state.
 
 In the most simple case, the item consists of the state's name, represented as a
-string. Such an item represents a state which is unconditionally enabled.
+string. Such an item represents a state which is unconditionally enabled. In any
+other case, the item consists of a map describing the state.
 
-In any other case, the item consists of a map with exactly one entry. The
-entry's key represents the state's name. The value is a map representing the
-state's properties. Each of those properties is optional:
-
+ * The mandatory entry with the key `name` denotes the issue state's name. The
+   value of this entry is the name
  * An entry with the key `condition` denotes the metadata condition. The value
    of this entry is a list of strings containing conditions for single pieces of
    metadata in implementation defined behavior. If the condition of the state

--- a/spec/Structure.md
+++ b/spec/Structure.md
@@ -34,7 +34,7 @@ other case, the item consists of a map describing the state.
    by the current state. The value of this entry is a list of strings, each
    matching an issue-state's name. Alternatively, if the state depends only on a
    single other state, a single string may be used.
- * An entry with the key `overrides` denotes states which are overridden by the
-   current state. Like for the `extends` entry, its value is a list of state
-   names or a single state name.
+ * The optional entry with the key `overrides` denotes states which are
+   overridden by the current state. Like for the `extends` entry, its value is a
+   list of state names or a single state name.
 


### PR DESCRIPTION
When updating the semantics, we forgot about the structure section. Hence, it contained lots of outdated wording. This PR updates the wording and simplifies the YAML format.