### PR TITLE
Extensions to IssueStateSet

### DIFF
--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -217,6 +217,16 @@ impl<C> From<state::IssueStateVec<C>> for IssueStateSet<C>
 }
 
 
+// Because #[derive(Default)] doesn't work for some reason
+impl<C> Default for IssueStateSet<C>
+    where C: state::Condition
+{
+    fn default() -> Self {
+        Self {data: Default::default()}
+    }
+}
+
+
 
 
 #[cfg(test)]

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -29,8 +29,9 @@
 //! issue's state as well as types implementing it for issue state containers.
 //!
 
-use std::sync::Arc;
 use std::collections;
+use std::slice;
+use std::sync::Arc;
 
 use error::*;
 use iter::LeftJoinable;
@@ -163,6 +164,14 @@ impl<C> IssueStateSet<C>
         }
 
         Ok(Self {data: data.into_boxed_slice()})
+    }
+
+    /// Get an iterator for iterating over the issue states within the set
+    ///
+    /// This iterator will yield an issue state only after all its dependencies.
+    ///
+    pub fn iter(&self) -> slice::Iter<Arc<state::IssueState<C>>> {
+        self.data.iter()
     }
 }
 

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -72,25 +72,8 @@ pub type ParseResult<T> = RResult<T, scanner::ScanError>;
 ///
 pub fn parse_issue_states<R, C, F, E>(
     parser: &mut parser::Parser<R>,
-    cond_parse: F
-) -> ParseResult<IssueStateSet<C>>
-    where R: Iterator<Item = char>,
-          C: state::Condition + Sized,
-          F: FnMut(&str) -> RResult<C, E>,
-          E: Error
-{
-    parse_issue_state_vec(parser, cond_parse).map(From::from)
-}
-
-
-/// Actual implementation of the parsing
-///
-/// We split the implementation in order to enable proper testing
-///
-fn parse_issue_state_vec<R, C, F, E>(
-    parser: &mut parser::Parser<R>,
     mut cond_parse: F
-) -> ParseResult<state::IssueStateVec<C>>
+) -> ParseResult<IssueStateSet<C>>
     where R: Iterator<Item = char>,
           C: state::Condition + Sized,
           F: FnMut(&str) -> RResult<C, E>,
@@ -131,7 +114,7 @@ fn parse_issue_state_vec<R, C, F, E>(
         retval.push(state);
     }
 
-    Ok(retval)
+    Ok(retval.into())
 }
 
 


### PR DESCRIPTION
This patch-set introduces a few extensions to `IssueStateSet`, making it more usable. It also makes use of the extensions for the YAML parser.